### PR TITLE
refactor: Put the previous constructors initialization method in their own method

### DIFF
--- a/src/main/java/com/visualizer/ViewModel/Selector/SelectorViewModel.java
+++ b/src/main/java/com/visualizer/ViewModel/Selector/SelectorViewModel.java
@@ -21,6 +21,12 @@ public class SelectorViewModel implements SelectorService
 
   public SelectorViewModel()
   {
+    populateChoiceBox();
+    setupListener();
+  }
+
+  private void populateChoiceBox()
+  {
     choices.addAll(
       new Pair("Pascal", "pas"),
       new Pair("C++", "cpp"),
@@ -32,7 +38,10 @@ public class SelectorViewModel implements SelectorService
       new Pair("Python", "py"),
       new Pair("PHP", "php")
     );
+  }
 
+  private void setupListener()
+  {
     selectedPair.addListener((obs, old, fresh) -> {
       if ( fresh == null )
       {


### PR DESCRIPTION
Put the previous constructors initialization method in their  own private method

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Simple refactor to improve readbility

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [xI have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

